### PR TITLE
fix overly-aggressive selector, make filters scrollable

### DIFF
--- a/styles/spell-book.css
+++ b/styles/spell-book.css
@@ -363,6 +363,8 @@
     flex-direction: column;
     border-bottom: 0.063rem solid var(--color-border-light-tertiary);
     background-color: var(--spell-book-bg-disabled);
+    overflow-y: auto;
+    flex-grow: 1;
   }
 
   input[name='filter-name'] {
@@ -1929,7 +1931,7 @@
 /* ----------------------------------------- */
 /*  Tab Navigation                           */
 /* ----------------------------------------- */
-.window-content > .tabs.tabs-right {
+.application.spell-book .window-content > .tabs.tabs-right {
   --icon-fill: var(--dnd5e-color-gold);
   --icon-size: 1rem;
   --tab-full-width: 2.75rem;


### PR DESCRIPTION
If desired, you can also add `scrollbar-gutter: static;` to the `.spell-book .spell-filters` styles. I didn't, since you don't use it elsewhere and I'm not sure what my preference is. This should result in the bottom part of the sidebar (number prepared/max prepared, save/reset/stats/loadouts) always being visible, regardless of window size.

Example of the scrollable filters:
<img width="735" height="509" alt="image" src="https://github.com/user-attachments/assets/391a9c57-d82b-488c-b570-c9f321e41da4" />