### PR TITLE
Hide Class Rules entry points from non-GM players

### DIFF
--- a/scripts/apps/player-spell-book.mjs
+++ b/scripts/apps/player-spell-book.mjs
@@ -564,6 +564,7 @@ export class SpellBook extends HandlebarsApplicationMixin(ApplicationV2) {
    * @param {HTMLElement} [target] - The button that was clicked
    */
   static #onOpenSettings(_event, target) {
+    if (!game.user.isGM) return;
     const scrollClass = target?.dataset?.scrollClass;
     const dialog = new ClassRules({ actor: this.actor });
     if (scrollClass) dialog.scrollToClass = scrollClass;
@@ -794,13 +795,16 @@ export class SpellBook extends HandlebarsApplicationMixin(ApplicationV2) {
     const classId = this._resolveClassId(tabId) ?? '';
     const li = document.createElement('li');
     li.className = 'spell-list-notice no-list-notice';
+    const button = game.user.isGM
+      ? `<button type="button" data-action="openSettings" data-scroll-class="${classId}">
+        <i class="fas fa-gear" aria-hidden="true"></i>
+        <span>${_loc('SPELLBOOK.NoListAssigned.OpenSettings')}</span>
+      </button>`
+      : '';
     li.innerHTML = `
       <p><strong>${_loc('SPELLBOOK.NoListAssigned.Title')}</strong></p>
       <p>${_loc('SPELLBOOK.NoListAssigned.Hint')}</p>
-      <button type="button" data-action="openSettings" data-scroll-class="${classId}">
-        <i class="fas fa-gear" aria-hidden="true"></i>
-        <span>${_loc('SPELLBOOK.NoListAssigned.OpenSettings')}</span>
-      </button>`;
+      ${button}`;
     return li;
   }
 

--- a/templates/apps/player/sidebar.hbs
+++ b/templates/apps/player/sidebar.hbs
@@ -5,10 +5,12 @@
   </div>
   <div class="sidebar-filter-section"></div>
   <div class="sidebar-controls">
-    <button type="button" class="sidebar-btn" data-action="openSettings"
-      data-tooltip="{{localize 'SPELLBOOK.UI.Settings'}}">
-      <i class="fas fa-cog" aria-hidden="true"></i>
-    </button>
+    {{#if isGM}}
+      <button type="button" class="sidebar-btn" data-action="openSettings"
+        data-tooltip="{{localize 'SPELLBOOK.UI.Settings'}}">
+        <i class="fas fa-cog" aria-hidden="true"></i>
+      </button>
+    {{/if}}
     <button type="button" class="sidebar-btn" data-action="openLoadoutDialog"
       data-tooltip="{{localize 'SPELLBOOK.Loadouts.Title'}}">
       <i class="fas fa-toolbox" aria-hidden="true"></i>


### PR DESCRIPTION
- Wrap sidebar Settings cog in `{{#if isGM}}` so only GMs see it
- Skip Open Class Rules button in `_buildNoListNotice` when user is not a GM
- Early-return in `#onOpenSettings` when invoked by a non-GM

Closes #194