### PR TITLE
Fix crash when user-spell-data pack is missing

### DIFF
--- a/module.json
+++ b/module.json
@@ -67,7 +67,7 @@
         "ASSISTANT": "OWNER",
         "PLAYER": "OWNER"
       },
-      "path": "/storage/user-spell-data",
+      "path": "storage/user-spell-data",
       "sort": 20000,
       "type": "JournalEntry"
     },

--- a/scripts/data/user-data.mjs
+++ b/scripts/data/user-data.mjs
@@ -5,6 +5,7 @@
  */
 
 import { FLAGS, MODULE, PACK, TEMPLATES } from '../constants.mjs';
+import { log } from '../utils/logger.mjs';
 
 const { renderTemplate } = foundry.applications.handlebars;
 
@@ -40,7 +41,12 @@ function decodeUuidKey(key) {
  * @returns {Promise<object|null>} The journal document or null
  */
 async function getJournal() {
-  const docs = await game.packs.get(PACK.USERDATA).getDocuments();
+  const pack = game.packs.get(PACK.USERDATA);
+  if (!pack) {
+    log(2, `User spell data pack "${PACK.USERDATA}" not found. Reinstall the module or restart the world to restore it.`);
+    return null;
+  }
+  const docs = await pack.getDocuments();
   return docs.find((doc) => doc.name === JOURNAL_NAME && doc.flags?.[MODULE.ID]?.isUserSpellDataJournal) ?? null;
 }
 


### PR DESCRIPTION
- Remove leading slash from user-spell-data pack path in module.json so Foundry registers the pack consistently across hosts
- Guard getJournal() against an undefined pack, logging a warning and returning null instead of throwing on .getDocuments()

Closes #198